### PR TITLE
Create request form redo

### DIFF
--- a/apps/frontend/src/components/CreateRequestModal/CreateRequestModal.tsx
+++ b/apps/frontend/src/components/CreateRequestModal/CreateRequestModal.tsx
@@ -2,7 +2,7 @@ import { Modal, Form, Container, Row, Col } from 'react-bootstrap';
 import { useParams, useSubmit } from 'react-router-dom';
 import styles from './CreateRequestModal.module.css';
 import CustomBtn from '../CustomBtn/CustomBtn';
-import { FormEvent, useState } from 'react';
+import { FormEvent, FocusEvent, ChangeEvent, useState } from 'react';
 
 interface Props {
   show: boolean;
@@ -17,6 +17,22 @@ export default function CreateRequestModal({ show, handleClose }: Props) {
     handleClose();
     setValidated(false);
   };
+
+  const validateTextArea = (event: FocusEvent<HTMLTextAreaElement>) => {
+    const textarea = event.currentTarget as HTMLTextAreaElement ;
+    const validPattern = /\s*(\S\s*){4,}/;
+
+    if (!validPattern.test(textarea.value)) {
+      textarea.setCustomValidity('The content needs to be at least 4 characters long.');
+    } else {
+      textarea.setCustomValidity('');
+    }
+
+    textarea.reportValidity();
+  }
+
+  const hideValidation = (event: ChangeEvent<HTMLTextAreaElement>) =>
+    event.currentTarget.setCustomValidity('');
     
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     const form = event.currentTarget;
@@ -51,7 +67,7 @@ export default function CreateRequestModal({ show, handleClose }: Props) {
           </Form.Group>
           <Form.Group className='mb-2' controlId='content'>
             <Form.Label column='sm'>Content<span className={styles.asterisk}>*</span></Form.Label>
-            <Form.Control as='textarea' rows={4} name='content' minLength={4} required />
+            <Form.Control as='textarea' rows={4} name='content' minLength={4} onChange={hideValidation} onBlur={validateTextArea} required />
             <Form.Control.Feedback type='invalid'>
               Please input some explanatory content.
             </Form.Control.Feedback>

--- a/apps/frontend/src/components/CreateRequestModal/CreateRequestModal.tsx
+++ b/apps/frontend/src/components/CreateRequestModal/CreateRequestModal.tsx
@@ -2,7 +2,7 @@ import { Modal, Form, Container, Row, Col } from 'react-bootstrap';
 import { useParams, useSubmit } from 'react-router-dom';
 import styles from './CreateRequestModal.module.css';
 import CustomBtn from '../CustomBtn/CustomBtn';
-import { FormEvent, FocusEvent, ChangeEvent } from 'react';
+import { FormEvent, useState } from 'react';
 
 interface Props {
   show: boolean;
@@ -10,28 +10,14 @@ interface Props {
 }
 
 export default function CreateRequestModal({ show, handleClose }: Props) {
+  const [validated, setValidated] = useState(false);
   const { id: neighborhoodId } = useParams();
   const submit = useSubmit();
-  const closeModal = () => handleClose();
-
-
-  const validateTextArea = (event: FocusEvent<HTMLTextAreaElement>) => {
-    const textarea = event.currentTarget as HTMLTextAreaElement ;
-    const validPattern = /\s*(\S\s*){4,}/;
+  const closeModal = () => {
+    handleClose();
+    setValidated(false);
+  };
     
-    if (!validPattern.test(textarea.value)) {
-      textarea.setCustomValidity('The content needs to be at least 4 characters long.');
-    } else {
-      textarea.setCustomValidity('');
-    }
-
-    textarea.reportValidity();
-  }
-
-  const hideValidation = (event: ChangeEvent<HTMLTextAreaElement>) =>
-    event.currentTarget.setCustomValidity('');
-  
-
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     const form = event.currentTarget;
     
@@ -39,7 +25,7 @@ export default function CreateRequestModal({ show, handleClose }: Props) {
       event.preventDefault();
       event.stopPropagation();
 
-      form.classList.add('was-validated');
+      setValidated(true);
     } else {
       submit(form, {
         method: 'post',
@@ -50,12 +36,12 @@ export default function CreateRequestModal({ show, handleClose }: Props) {
   };  
 
   return (
-    <Modal show={show} onHide={handleClose} animation={true} backdrop='static' centered>
+    <Modal show={show} onHide={closeModal} animation={true} backdrop='static' centered>
       <Modal.Header closeButton>
         <Modal.Title>Create a request</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <Form role='form' noValidate onSubmit={handleSubmit} className={styles.createReqForm}>
+        <Form role='form' noValidate validated={validated} onSubmit={handleSubmit} className={styles.createReqForm}>
           <Form.Group className='mb-3' controlId='title'>
             <Form.Label column='sm'>Title<span className={styles.asterisk}>*</span></Form.Label>
             <Form.Control type='text' name='title' minLength={4} pattern='\s*(\S\s*){4,}' required />
@@ -65,7 +51,7 @@ export default function CreateRequestModal({ show, handleClose }: Props) {
           </Form.Group>
           <Form.Group className='mb-2' controlId='content'>
             <Form.Label column='sm'>Content<span className={styles.asterisk}>*</span></Form.Label>
-            <Form.Control as='textarea' rows={4} name='content' onChange={hideValidation} onBlur={validateTextArea} minLength={4} required />
+            <Form.Control as='textarea' rows={4} name='content' minLength={4} required />
             <Form.Control.Feedback type='invalid'>
               Please input some explanatory content.
             </Form.Control.Feedback>


### PR DESCRIPTION
I updated the design for the create request form. I wanted to add [bootstrap form validation](https://react-bootstrap.netlify.app/docs/forms/validation/) but I couldn't for the life of me figure out how to do it using the react-router-dom `Form` component. If I revert to using react bootstrap's `Form` component, the request isn't made successfully. Let me know if you can find anything on this. It'd be nice to use it on all forms, but they're all built in the same way.